### PR TITLE
docs: fix typo in credits section

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,4 +372,4 @@ Open `src/data/site.json` and edit the information describing your recent site l
 
 ## Credits
 
-Inpired by [weeby.studio](https://weeby.studio) Intro theme.
+Inspired by [weeby.studio](https://weeby.studio) Intro theme.


### PR DESCRIPTION
## Summary
- fix typo in README credits

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f4860650c83319d587c43353376fb